### PR TITLE
Test: 가계부 조회 테스트코드 리팩토링 (#41)

### DIFF
--- a/src/financial-ledger/__test__/financial-ledger.service.spec.ts
+++ b/src/financial-ledger/__test__/financial-ledger.service.spec.ts
@@ -190,26 +190,25 @@ describe('FinancialLedgerService', () => {
 
       try {
         // When
-        const result = await repository.getOneMemo(1, user.id);
+        const result = repository.getOneMemo(1, user.id);
         // Then
-        expect(result).resolves.toEqual(UnauthorizedException);
+        expect(result).rejects.toEqual(
+          new NotFoundException('해당하는 가계부 내역을 찾을 수 없습니다.'),
+        );
       } catch (e) {}
     });
   });
 
   describe('readList', () => {
-    it('로그인을 하지않고 리스트를 조회할때 UnauthorizedException 발생하는가', async () => {
+    it('조회한 가계부 리스트가 존재하는가', async () => {
       // Given
       const user = getUser();
       const em = dataSource.createEntityManager();
       await em.save(user);
 
-      try {
-        // When
-        const result = await repository.getAllMemo(user.id);
-        // Then
-        expect(result).toThrowError(UnauthorizedException);
-      } catch (e) {}
+      // When
+      const result = repository.getAllMemo(user.id);
+      expect(result).resolves.toBeDefined();
     });
   });
 });

--- a/src/financial-ledger/financial-ledger.repository.ts
+++ b/src/financial-ledger/financial-ledger.repository.ts
@@ -62,10 +62,6 @@ export class FinancialLedgerRepository extends Repository<FinancialLedger> {
     const groupData = await this.findDayGroup(userId);
     const userData = await this.findUserList(userId);
 
-    if (groupData.length === 0 || userData.length === 0) {
-      throw new UnauthorizedException('가계부 접근 권한이 없습니다.');
-    }
-
     return { groupData, userData };
   }
 


### PR DESCRIPTION
* Setting: 가계부 모듈 생성, env파일 설정

가계부 financial-ledger 모듈 생성
모듈내 controller, service 생성
MySQL사용을 위한 .env 생성 및 설정

* Refactor: FinancialLedger 엔티티 이름 변경

'FinantialLedger'로 되어있던걸 'FinancialLedger'로 변경

* Setting: docker-compose  세팅

Docker로 MySQL관리하기

* Feat: 가계부 글 작성

financial-ledger 모듈에 컨트롤러, 서비스, 레파지토리 내 createMemo() 메서드 추가

* Feat: 가계부 상세내역 보기

financial-ledger 모듈의 컨트롤러, 서비스에 가계부 상세내역 보기를 위한 getOneMemo() 메서드 추가

* Feat: 가계부 리스트 조회 (일자별 그룹화)

일자별 그룹화한 데이터 'groupDay'

todo
-일자별 그룹화에 해당하는 하위 가계부 내역 추가필요

* Update: 가계부 리스트 조회 (일자별 그룹화 보완 + 유저 내역 전부 조회)

Dto 수정
-FinancialLedgerDto : 유저 작성용
-FinancialLedgerResultDto : 리스트 전체조회 유저 전달용
-FinancialLedgerGroupDto : 일자별 그룹화 조회용 (가공 목적)
-FinancialLedgerListDto : 본인작성 가계부 내역 전부 조회용 (가공 목적)

Repository
-findDayGroup(), findUserList() 메소드 사용으로 getAll()에서 FinancialLedgerResultDto 형태로 전달하기위해 가공

* Update: 가계부 리스트 조회 (응답 객체 데이터 가공)

일자별 사용금액과 해당날에 작성한 내역을 한번에 담아서FinancialLedgerResultDto객체로 응답함.
포스트맨으로 확인결과 {}로 좀더 수정이 필요함.

* Setting : ValidationPipe설치

유효성 검사를 위해 디펜던시 추가
$ npm i --save class-validator class-transformer

* Feat: 가계부 작성시 유효성 체크

FinancialLedgerDto에 class-validator추가

* Fix: FinancialLedgerRepository 삭제

TypeOrm및 @EntityRepository 등 오류발생으로 수정 및  FinancialLedgerRepository삭제(Service에서 처리)

* Feat : Interceptor 설정

유저 응답값 처리를 위한 인터셉터 추가

* Update : 가계부 전체 조회시 응답데이터 타입 변경

기존 Map타입으로 설정해서 포스트맨에서 데이터가 안왔었음.
FinancialLedgerListDto -> FinancialLedgerDayDto -> FinancialLedgerResponseDto 최종타입으로 감싸서 데이터 전달로 변경

포스트맨으로 데이터 확인 완료

* Update: 가계부 상세내역 확인 시 응답 데이터 Dto타입으로 변경

기존 상세내역 조회시 findOne으로 디비 조회결과 바로 전달하던걸 FinancialLedgerDto 타입으로 바꿔서 전달

* Update:상세내역 조회 삭제여부 확인 추가, API URL 수정

API URL 수정 '/financial-ledgers'
상세내역 조회할때 삭제여부 확인이 없어서 추가

* Upgrade: 유저 데이터 연동해서 가계부 작성, 상세내역, 리스트 확인 완료

유저 로그인 (토큰인증) 성공 후 가계부 작성, 상세내역 보기, 리스트 확인 완료

* Feature : 유효성 검사 추가

FinancialLedgerWriteDto에 class-validator 데코레이터 추가
없는 번호의 가계부 내역을 확인할 시 NotFoundException

* Feature: 컨트롤러에 HTTP 상태코드 데코레이터 추가

 @HttpCode(201) : 글작성
 @HttpCode(200) : 상세내역 조회, 전체 리스트 조회

* Feature: Swagger 추가

FinancialLedgerController, FinancialLedgerWriteDto에 스웨거 데코레이터 추가

* Chore: fastify-swagger 삭제

잘못 설치한 fastify-swagger npm 삭제했습니다

* Refactor: FinancialLedgerRepository 분리

FinancialLedgerService에 있던 DB관련 코드 FinancialLedgerRepository 파일로 분리

* Test: 테스트 추가 - 가계부 작성, 상세내역 조회, 리스트 조회

가계부 작성, 상세내역 조회, 리스트 조회 부분 테스트 코드 추가

* Refactor : try-catch 에러 확인, 안쓰는 import제거

try-catch문에서 expect 에러 확인
잘못추가된 임포트 제거

* Test : 테스트 코드 리팩토링 (Exception, try-catch)

리스트 조회시 빈배열일 경우 UnauthorizedException 였으나 예외처리없이 빈배열을 확인하기로 함.
try-catch에서 expect가 안찍히고 바로 지나가서 수정함.

Co-authored-by: Hyunseok Ko <56003992+khsexk@users.noreply.github.com>